### PR TITLE
Archive 2023 and stage 2024 site

### DIFF
--- a/_2023_pages/agenda.html
+++ b/_2023_pages/agenda.html
@@ -1,6 +1,6 @@
 ---
 layout: 2023_default
-permalink: /agenda
+permalink: /2023/agenda
 title: Agenda
 published: true
 ---

--- a/_2023_pages/calendar.html
+++ b/_2023_pages/calendar.html
@@ -1,6 +1,6 @@
 ---
 layout: 2023_default
-permalink: /calendar
+permalink: /2023/calendar
 title: Calendar
 published: true
 ---

--- a/_2023_pages/calendar_2023.html
+++ b/_2023_pages/calendar_2023.html
@@ -2,7 +2,7 @@
 layout: 2023_default
 permalink: /2023/calendar
 title: Calendar
-published: true
+published: false
 ---
 <!-- calendar on main page -->
 

--- a/_2023_pages/workshop_speakers.html
+++ b/_2023_pages/workshop_speakers.html
@@ -1,6 +1,6 @@
 ---
 layout: 2023_default
-permalink: /speakers
+permalink: /2023/speakers
 title: Workshop Speakers
 ---
 

--- a/_2024_pages/agenda.html
+++ b/_2024_pages/agenda.html
@@ -1,0 +1,111 @@
+---
+layout: 2024_home_TBA
+permalink: /agenda
+title: Agenda
+published: true
+---
+    <!--background color-->
+    <script type="text/javascript">
+        document.write ('<body style="background: Gainsboro; background-attachment: fixed;">')
+    </script>
+
+    <div class="event event-frame">
+    <div class="event black-frame">
+      <h1>{{ page.title }}</h1>
+
+
+
+        {% for day in site.data.yml_2024.dates %}
+            <h2>{{ day.day-full }}, {{ day.date }} </h2>
+            <table class="agenda">
+                <thead>
+                    <tr>
+                        <th class="row-1 agenda-time"><center>Time</center></th>
+                        <th class="row-2 agenda-activity"><center>Activity</center></th>
+                    </tr>
+                </thead>
+
+                {% for agenda in site.data.yml_2024.workshops %}
+                    <tr>
+                        {% if agenda.day == day.day-abbv %}
+                        <td>{{ agenda.time }}</td>
+                        <td><u>{{ agenda.title }}</u><br>{% if agenda.speakers[0].name!="none" %}{% assign workshop-speakers = agenda.speaker-type | append: ": " %}{% for speaker in agenda.speakers %}{% capture temp-speakers %} {{workshop-speakers}}{{ speaker.name }}{% for campus in site.data.yml_2024.campuses %}{% if speaker.org == campus.abbv %} ({{campus.name}}){% endif %}{% endfor %}{% if forloop.index != agenda.speakers.size %}, {% endif %}{% endcapture %}{% assign workshop-speakers = temp-speakers %}{% endfor %}<b>{{ workshop-speakers }}</b><br>{% endif %}<br>{{ agenda.description }}<br>  </td>
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+            </table>
+        {% endfor %}
+
+        <!-- h2>Tuesday</h2>
+        <table class="agenda">
+            <thead>
+                <tr>
+                    <th class="row-1 agenda-time"><center>Time</center></th>
+                    <th class="row-2 agenda-activity"><center>Activity</center></th>
+                </tr>
+
+            </thead>
+
+            {% for agenda in site.data.yml_2024.tuesday %}
+                <tr>
+                    <td>{{ agenda.time }}</td>
+                    <td>{{ agenda.info }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+
+        <h2>Wednesday</h2>
+        <table class="agenda">
+            <thead>
+                <tr>
+                    <th class="row-1 agenda-time"><center>Time</center></th>
+                    <th class="row-2 agenda-activity"><center>Activity</center></th>
+                </tr>
+
+            </thead>
+
+            {% for agenda in site.data.yml_2024.wednesday %}
+                <tr>
+                    <td>{{ agenda.time }}</td>
+                    <td>{{ agenda.info }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+
+        <h2>Thursday</h2>
+        <table class="agenda">
+            <thead>
+                <tr>
+                    <th class="row-1 agenda-time"><center>Time</center></th>
+                    <th class="row-2 agenda-activity"><center>Activity</center></th>
+                </tr>
+
+            </thead>
+
+            {% for agenda in site.data.yml_2024.thursday %}
+                <tr>
+                    <td>{{ agenda.time }}</td>
+                    <td>{{ agenda.info }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+
+            <h2>Friday</h2>
+        <table class="agenda">
+            <thead>
+                <tr>
+                    <th class="row-1 agenda-time"><center>Time</center></th>
+                    <th class="row-2 agenda-activity"><center>Activity</center></th>
+                </tr>
+
+            </thead>
+
+            {% for agenda in site.data.yml_2024.friday %}
+                <tr>
+                    <td>{{ agenda.time }}</td>
+                    <td>{{ agenda.info }}</td>
+                </tr>
+            {% endfor %}
+        </table -->
+    </div>
+    </div>

--- a/_2024_pages/calendar.html
+++ b/_2024_pages/calendar.html
@@ -1,0 +1,7 @@
+---
+layout: 2024_home_TBA
+permalink: /calendar
+title: Calendar
+published: false
+---
+

--- a/_2024_pages/index.html
+++ b/_2024_pages/index.html
@@ -1,0 +1,6 @@
+---
+layout: 2024_home_TBA
+permalink: /index
+title: UC Love Data Week 2024
+published: true
+---

--- a/_2024_pages/index_dev.html
+++ b/_2024_pages/index_dev.html
@@ -1,0 +1,5 @@
+---
+layout: 2024_home_TBA
+permalink: /index_dev
+title: UC Love Data Week 2024
+---

--- a/_2024_pages/workshop_speakers.html
+++ b/_2024_pages/workshop_speakers.html
@@ -1,0 +1,8 @@
+---
+layout: 2024_home_TBA
+permalink: /speakers
+title: Workshop Speakers
+published: false
+---
+
+    {% include 2024_includes/workshop_speakers.html %}

--- a/_data/yml_2024/campuses.yml
+++ b/_data/yml_2024/campuses.yml
@@ -1,0 +1,153 @@
+- name: UC Berkeley
+  abbv: ucb-datapeer
+  image: ../assets/img/campuses/ucb-datapeer.png
+  alt: Berkeley Data Peer Consulting
+  url: https://data.berkeley.edu/ds-peer-consulting
+  p-campus: n  # p-campus: will it show on front page logo for particpating campus
+
+- name: UC Berkeley
+  abbv: ucb
+  image: 
+  alt: 
+  url: https://www.berkeley.edu
+  p-campus: n  # p-campus: will it show on front page logo for particpating campus
+
+- name: UC Berkeley
+  abbv: ucb-iso
+  image: ../assets/img/campuses/ucb-iso.png
+  alt: Berkeley Information Security Office
+  url: https://security.berkeley.edu/
+  p-campus: n  # p-campus: will it show on front page logo for particpating campus
+
+- name: UC Berkeley
+  abbv: ucb-lib
+  image: ../assets/img/campuses/ucb-lib.png
+  alt: Library Data Services Program
+  url: https://www.lib.berkeley.edu/research-support/data-gis
+  p-campus: y  # p-campus: will it show on front page logo for particpating campus
+
+- name: UC Berkeley
+  abbv: ucb-rit
+  image: ../assets/img/campuses/ucb-rit.png
+  alt: Berkeley Research IT
+  url: https://research-it.berkeley.edu/
+  p-campus: n  # p-campus: will it show on front page logo for particpating campus
+
+- name: UC Berkeley
+  abbv: ucb-rdm
+  image: ../assets/img/campuses/ucb-rdm.png
+  alt: Berkeley Research Data Management
+  url: https://researchdata.berkeley.edu/
+  p-campus: y  # p-campus: will it show on front page logo for particpating campus
+
+- name: UC Davis
+  abbv: ucd-dl
+  image: /assets/img/campuses/ucd-dl.png
+  alt: UC Davis DataLab, Data Science and Informatics
+  url: https://datalab.ucdavis.edu/
+  p-campus: y
+
+- name: UC Davis Health Clinical and Translational Science Center
+  abbv: ucd-ctsc
+  image: /assets/img/campuses/ucd-ctsc.png
+  alt: UC Davis, Health
+  url: https://health.ucdavis.edu/ctsc/
+  p-campus: y
+
+- name: UC Irvine
+  abbv: uci
+  image: /assets/img/campuses/uci-lib.png
+  alt: UC Irvine Libraries
+  url: https://www.lib.uci.edu/dss/data-curation
+  p-campus: y
+
+- name: UCLA
+  abbv: ucla-dsc
+  image: /assets/img/campuses/ucla-dsc.png
+  alt: UCLA Library Data Science Center
+  url: https://www.library.ucla.edu/location/data-science-center
+  p-campus: y
+
+- name: UCLA
+  abbv: ucla-lib
+  image: /assets/img/campuses/ucla-lib-2022.png
+  alt: UCLA Library
+  url: https://www.library.ucla.edu/location/data-science-center
+  p-campus: y
+
+- name: UC Merced
+  abbv: ucm
+  image: /assets/img/campuses/ucm-lib.png
+  alt: UC Merced Library
+  url: http://library.ucmerced.edu/research-data-curation
+  p-campus: y
+
+- name: UC Riverside
+  abbv: ucr-lib
+  image: /assets/img/campuses/ucr-lib.png
+  alt: UC Riverside Library
+  url: https://guides.lib.ucr.edu/datamanagement
+  p-campus: y
+
+- name: UC Santa Barbara
+  abbv: ucsb
+  image: /assets/img/campuses/ucsb-library.png
+  alt: UC Santa Barbara Library
+  url: https://www.library.ucsb.edu/research-data-services
+  p-campus: y
+
+- name: UC San Diego
+  abbv: ucsd-lib
+  image: /assets/img/campuses/ucsd-lib.png
+  alt: The Library, UC San Diego
+  url: https://library.ucsd.edu/research-and-collections/data-curation/
+  p-campus: y
+
+- name: UC San Francisco
+  abbv: ucsf
+  image: /assets/img/campuses/ucsf-lib.svg
+  alt: UCSF Library
+  url: https://www.library.ucsf.edu/ask-an-expert/data-science/data-management/
+  p-campus: y
+
+- name: California Digital Library
+  abbv: cdl
+  image: /assets/img/campuses/cdl.png
+  alt: California Digital Library
+  url: https://cdlib.org/
+  p-campus: y
+
+- name: UC San Diego
+  abbv: ucsd
+  image: /assets/img/campuses/ucsd.png
+  alt: UC San Diego
+  url: https://www.ucsd.edu
+  p-campus: n
+
+- name: UCLA
+  abbv: ucla
+  image: 
+  alt: 
+  url: https://www.ucla.edu
+  p-campus: n
+
+- name: California Digital Library
+  abbv: cdl
+  image: /assets/img/campuses/uc3.png
+  alt: UC3
+  url: https://uc3.cdlib.org/
+  p-campus: n
+
+- name: UC Davis
+  abbv: ucd-lib
+  image: /assets/img/campuses/ucd-lib.jpg
+  alt: UC Davis Library
+  url: https://www.library.ucdavis.edu/
+  p-campus: n
+
+- name: UC ANR
+  abbv: uc-anr
+  image: ../assets/img/campuses/uc-anr.png
+  alt: UC Agriculture and Natural Resources
+  url: https://ucanr.edu/
+  p-campus: y  # p-campus: will it show on front page logo for particpating campus

--- a/_data/yml_2024/contacts.yml
+++ b/_data/yml_2024/contacts.yml
@@ -1,0 +1,47 @@
+- campus: UC Berkeley
+  name: Anna Sackmann
+  email: asackmann&lt;at&gt;berkeley.edu
+
+- campus: UC Davis
+  name: Emily Atkinson
+  email: eeatkinson&lt;at&gt;ucdavis.edu
+
+- campus: UC Irvine
+  name: Wasila Dahdul
+  email: wdahdul&lt;at&gt;uci.edu
+
+- campus: UCLA
+  name: Ashley Peterson
+  email: ashleypeterson&lt;at&gt;library.ucla.edu
+
+- campus: UC Merced
+  name: Derek Devnich
+  email: ddevnich&lt;at&gt;ucmerced.edu
+
+- campus: UC Riverside
+  name: Kat Koziar
+  email: katherine.koziar&lt;at&gt;ucr.edu
+
+- campus: UC Santa Cruz
+  name: Christy Caldwell
+  email: caldwell&lt;at&gt;ucsc.edu
+
+- campus: UC Santa Barbara
+  name: Renata Curty
+  email: rcurty&lt;at&gt;ucsb.edu
+
+- campus: UC San Diego
+  name: Stephanie Labou
+  email: slabou&lt;at&gt;ucsd.edu
+
+- campus: UC San Francisco
+  name: Ariel Deardorff
+  email: ariel.deardorff&lt;at&gt;ucsf.edu
+
+- campus: UC Ag & Natural Resources
+  name: Andy Lyons
+  email: andlyons&lt;at&gt;ucanr.edu
+
+- campus: California Digital Library
+  name: Maria Praetzellis
+  email: maria.praetzellis&lt;at&gt;ucop.edu

--- a/_data/yml_2024/dates.yml
+++ b/_data/yml_2024/dates.yml
@@ -1,0 +1,24 @@
+- date: Feb 12, 2024
+  day-full: Monday
+  day-abbv: m
+  iso8601: 220240212
+
+- date: Feb 13, 2024
+  day-full: Tuesday
+  day-abbv: t
+  iso8601: 20240213
+
+- date: Feb 14, 2024
+  day-full: Wednesday
+  day-abbv: w
+  iso8601: 20240214
+
+- date: Feb 15, 2024
+  day-full: Thursday
+  day-abbv: h
+  iso8601: 20240215
+
+- date: Feb 16, 2024
+  day-full: Friday
+  day-abbv: f
+  iso8601: 20240216

--- a/_data/yml_2024/workshop_type.yml
+++ b/_data/yml_2024/workshop_type.yml
@@ -1,0 +1,25 @@
+- type: demo
+  type_color: 
+  type_description_short:  Demonstration
+  type_description_long:
+
+- type: lecture
+  type_color: 
+  type_description_short:  Seminar
+  type_description_long:
+
+- type: hands-on
+  type_color: 
+  type_description_short:  Hands-on
+  type_description_long:
+
+- type: discussion
+  type_color: 
+  type_description_short:  Discussion
+  type_description_long:
+
+- type: other
+  type_color: 
+  type_description_short:  Other
+  type_description_long:
+

--- a/_data/yml_2024/workshops.yml
+++ b/_data/yml_2024/workshops.yml
@@ -1,0 +1,712 @@
+#Monday
+
+- title: Wikidata Basics
+  name: wikidatabasics
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Kat Koziar, org: ucr-lib},
+    {name: Leigh Phan, org: ucla-dsc}
+  ]
+  img:  Wikidata-logo-v3.png
+  thumbnail:  Wikidata-logo-v3.png
+  alt:  "wikidata logo on clear background: stylized bar codes with bars in three colors (red, green, and blue) with the word wikidata beneath"
+  day: m
+  time: 10-11am
+  start: 10
+  duration: 60
+  type: lecture
+  description: Have you heard of linked data or Wikidata and want to know what they
+    are, and how you can use them?  Have you ever wondered why there are so many wiki*thing*.org
+    websites, and how they're interconnected? This is the workshop for you! <br><br>Wikidata
+    is a free and open knowledge base that provides structured, linked data not just
+    for Wikipedia, but to anyone. It is used globally by many sites and services.<br><br>In
+    this workshop we will describe what Wikidata is and used for; how it's connected
+    to Wikimedia projects (such as Wikipedia); how it's leveraged by many other sites
+    and services as a point of open data; and more importantly, an overview of how
+    you can edit and use it.
+  registration-page: https://www.eventbrite.com/e/wikidata-basics-tickets-488808147327
+  recording:
+  slides:
+
+- title: Managing and Sharing Data for NIH Projects
+  name: nihshare
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Wasila Dahdul, org: uci},
+    {name: Derek Devnich, org: ucm},
+    {name: Reid Otsuji, org: ucsd},
+    {name: Ho Jung Yoo, org: ucsd}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: m
+  time: 11am-12pm
+  start: 11
+  duration: 60
+  type: lecture
+  description: NIH has issued a new Data Management and Sharing Policy (effective
+    January 25, 2023) to promote the sharing of scientific data and its reuse in future
+    research. Join this workshop to learn about data sharing strategies and resources
+    that will help you comply with the new NIH policy. We will cover good practices
+    for data management, how to find standards for data and metadata, and selecting
+    an appropriate data repository for your discipline or data type. Participants
+    will come away with a better understanding of the process of data management and
+    how to locate resources that align with the new NIH policy.
+  registration-page: https://spaces.lib.uci.edu/event/9988808
+  recording: https://vimeo.com/799560197
+  slides: https://drive.google.com/file/d/1Jqp_mLUj34Dh042vWKRE9__OmCP9BRXv/view?usp=sharing
+
+- title: Writing a Data Management and Sharing Plan for NIH
+  name: nihdmp
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Ariel Deardorff, org: ucsf},
+    {name: Wasila Dahdul, org: uci}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: m
+  time: 1-2pm
+  start: 1
+  duration: 60
+  type: hands-on
+  description: Have you heard of the new NIH Data Management and Sharing Policy but
+    want to learn more about how to comply? Want some more guidance on writing your
+    Data Management and Sharing Plan (DMS plan)? In this hands-on workshop we will
+    quickly introduce the new policy and then work through each section of the DMS
+    plan so you understand what to write and can start drafting your own plan. We
+    will also cover how to locate DMS plan templates and sample plans, and highlight
+    resources for learning more.
+  registration-page: https://calendars.library.ucsf.edu/event/9986694
+  recording: https://ucsf.box.com/s/depf1joy1f113nkunt92c9y1gea1cank 
+  slides: https://ucsf.box.com/s/depf1joy1f113nkunt92c9y1gea1cank
+
+- title: "Data Loofah - help you identify errors in your data"
+  name: dataloofah
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Matthew Ponzini, org: ucd-ctsc}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: m
+  time: 2-3pm
+  start: 2
+  duration: 60
+  type: demo
+  description: "Data cleaning can be a time consuming aspect of research. Join us
+    for look at Loofah, a tool to help researchers clean their data. Data Loofah was
+    developed within the UCD Clinical & Translational Science Center (CTSC) – Biostatistics
+    program. This interactive demonstration will provide and overview of the tool
+    including the scope, how it works and use cases. Attendees will be provided with
+    instruction on how to use the code in your research."
+  registration-page: https://tinyurl.com/DataLoofah
+  recording: https://tinyurl.com/DataLoofahDemo
+  slides: 
+
+- title: Python Users Group
+  name: pythonusers
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Maggie Beherens, org: ucd-dl},
+    {name: Nick Ulle, org: ucd-dl}
+  ]
+  img:  Python_logo.png
+  thumbnail:  Python_logo.png
+  alt:  "Python logo: the words Python under a blue and yellow symbol"
+  day: m
+  time: 2-3pm
+  start: 2
+  duration: 60
+  type: discussion
+  description: "Come join the Davis Python Users Group to talk about all things Python!
+    In this 'birds of a feather' session we invite you to talk about how you use Python
+    in your research workflows, general questions you have about the language, and/or
+    how to start a community of practice for Python users at your institution."
+  registration-page: https://registration.genomecenter.ucdavis.edu/events/PythonUsersGroupCross-UCMeetup/
+  recording:
+  slides:
+
+- title: "FAIR and ML, AI Readiness, and AI Reproducibility (FARR)"
+  name: fairdata
+  speaker-type: "Speaker"
+  speakers: [
+  {name: Christine Kirkpatrick, org: sdsc}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: m
+  time: 3-4pm
+  start: 3
+  duration: 60
+  type: hands-on
+  description: "With the emergence of machine learning (ML) usage in research comes greater complexity for data stewards, 
+    research facilitators, and researchers. This session will introduce FAIR and ML, AI Readiness with a focus on the 
+    role of institutions and data repositories, and AI reproducibility. Participants will be encouraged through 
+    interactive, live polls, and open discussion to discuss their challenges, pain points, and interest as it 
+    relates to any of the topics."
+  registration-page: https://ucsd.zoom.us/meeting/register/tJcofu-tqTIjHNK69ooj3jOSFeZ6pJUVhH92
+  recording: https://drive.google.com/file/d/1UhViT37xdq4RZbPFsngNNLj0cTTdA6X-/view?usp=share_link 
+  slides: https://static.mentimeter.com/screenshot/pdfs/I%20Love%20Data%20FARR.pdf?seriesId=alk55qh6hfjcf9ti11rgcsck9vp6dcn3&screenshotTargetUrl=https%3A%2F%2Fwww.mentimeter.com%2Fpreview&_ga=2.208398994.1621205896.1676319283-1974507888.1675723459&_gl=1*s5wv8y*_ga*MTk3NDUwNzg4OC4xNjc1NzIzNDU5*_ga_TCT6BBBKGN*MTY3NjQwNTc0OS44LjEuMTY3NjQwNTc1NS4wLjAuMA..*_ga_5V8GZ3NSZE*MTY3NjQwNTc0OS44LjEuMTY3NjQwNTc1NS4wLjAuMA
+
+- title: "Data Visualization: Dos and Donts"
+  name: dataviz
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Greg Janee, org: ucsb},
+    {name: Renata Curty, org: ucsb}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: m
+  time: 4-5pm
+  start: 4
+  duration: 60
+  type: lecture
+  description: Data visualizations can be powerful tools to present patterns and insights
+    from research findings. However, the effectiveness of communicating data visually
+    is highly dependent on key design and accuracy principles. Join us in a discussion
+    about what makes good data visualizations and things that should be avoided at
+    all costs. This session will cover some bad and good real-world examples, and
+    attendees will walk away with essential tips to better represent their data in
+    a graphical form.
+  registration-page: https://www.library.ucsb.edu/events-exhibitions/data-visualization-dos-and-donts
+  recording:
+  slides: https://docs.google.com/presentation/d/1IPxv7Fl6NYaG2e3GbpJoQSIeX0hZvvG1CckUDUDjLjA/edit?usp=sharing
+
+#Tuesday
+
+- title: 'Stepping outside the CAVE: Developments in Virtual Reality technology for
+    3D data exploration'
+  name: vr
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Oliver Kryelos, org: ucd-dl},
+    {name: Pamela Reynolds, org: ucd-dl}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: t
+  time: 10-11am
+  start: 10
+  duration: 60
+  type: lecture
+  description: "Virtual Reality (VR) has evolved from an expensive and finicky niche
+    technology only available at well-funded large institutions, into a practical
+    consumer product with tremendous research potential. While current-generation
+    VR devices are primarily intended for the video gaming market, their use is not
+    limited to gaming and has tremendous potential for researchers. The VR Research
+    Initiative at UC Davis DataLab is translating visualization technology initially
+    created for the UC Davis W.M. Keck Center for Active Visualization in the Earth
+    Sciences (KeckCAVES), to function with modern commodity VR devices. By developing
+    and supporting open-source software for gaming VR headsets, DataLab seeks to promote
+    equitable access to emerging technologies and enable diverse communities of researchers
+    and the public to explore 3D data. In this session, we will discuss the fundamental
+    principles and reasons why VR is highly effective for the analysis of large and
+    complex three-dimensional data. We will introduce several concrete VR applications
+    based on those principles that are being developed at UC Davis DataLab, and will
+    describe how participants can build their own VR systems, able to run DataLabs
+    VR applications, at their own institutions. By the end of this session participants
+    will be able to: describe how current-generation virtual reality (VR) technology
+    such as VR headsets meant for gaming can effectively be used for scientific data
+    analysis; discuss why VR is useful for analysis of data, specifically complex
+    and large three-dimensional data; and identify where to go to learn more about
+    setting up their own VR systems using the latest VR technologies for research."
+  registration-page: https://registration.genomecenter.ucdavis.edu/events/SteppingOutsidetheCAVEVirtualReality/
+  recording:
+  slides:
+
+- title: "Web Archiving as Data"
+  name: webarchive
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Tori Maches, org: ucsd},
+    {name: Stephanie Labou, org: ucsd}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: t
+  time: 11am-12pm
+  start: 11
+  duration: 60
+  type: demo
+  description: "Put on your digital historian hat and join us for an exploration of web archiving as data! In this session we will answer questions such as: What even is web archiving? Why should I care about it? How do I access web archived stuff? What kind of analysis can I do with it? We will use as a case study UC San Diego's guidance for covid prevention, as posted on websites, from Spring 2020 - present. We'll demonstrate how to retrieve the history of a website, work with the html text data in Python, and track changes regarding campus guidance on topics like masking and remote instruction."
+  registration-page: https://ucsd.zoom.us/meeting/register/tJMtdOyuqT4oE9ZLbhii8F9S80JeEKZH92j-
+  recording:  https://drive.google.com/file/d/1MOCOac8uZRcO3y519yT2dwYNFv0VkIAp/view?usp=share_link
+  slides: https://docs.google.com/presentation/d/1VW6vpZWEiKu7O55pWAAbafXYvrJ82_0EDsg-pnsWrE8/edit?usp=sharing
+
+
+- title: Reproducibility for Everyone
+  name: everyone
+  speaker-type: "Speaker"
+  speakers: [
+    {name: April Clyburne-Sherin, org: r4e},
+    {name: Kanika Khanna, org: ucb},
+    {name: Teena Bajaj, org: ucb},
+    {name: Victoria Farrar, org: r4e},
+    {name: Nafisa Jadavji, org: r4e}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: t
+  time: 11am-12:30pm
+  start: 11
+  duration: 90
+  type: hands-on
+  description: "Rigor and reproducibility are at the core of modern science. Many new initiatives and 
+  tools have been established to address barriers to reproducibility. While very welcome, these projects 
+  have led to a proliferation of online tools and resources which can be hard to sift through. <br>
+  <br>
+  Reproducibility for Everyone (R4E) is a global, community-led reproducibility education initiative. R4E 
+  runs practical and accessible workshops to introduce the concept of reproducibility to researchers. We 
+  demonstrate reproducible tools and methods that can improve research by making it more efficient, 
+  transparent, and rigorous. Every R4E workshop is customized for the audience. Since 2018, R4E volunteer 
+  instructors have reached over 2500 researchers around the world through over 40 workshops.<br>
+  <br>
+  This workshop will introduce reproducible workflows and a range of tools along the themes of organization, 
+  documentation, analysis, and dissemination. After a brief introduction to the topic of reproducibility, 
+  the workshop will provide specific tips and tools useful in improving daily research workflows. The content 
+  will include modules such as data management, electronic lab notebooks, reproducible bioinformatics tools 
+  and methods, protocol and reagent sharing, data visualization, and version control. All modules include 
+  interactive learning, real-time participation, and active knowledge sharing. The methods and tools introduced 
+  help researchers share work with their future self, their immediate colleagues, and the wider scientific community. <br>
+  <br>
+  Following this workshop, participants will be able to:
+  <ul>
+  <li>
+  Apply a conceptual framework for reproducibility, replicability, and robustness of research.</li>
+  <li>
+  Explore practical, accessible tools and methods for advancing the reproducibility of research.</li>
+  <li>
+  Reuse and adapt the Reproducibility for Everyone modular curriculum to their own training and research needs.</li>
+  <li>
+  Evaluate their reproducibility barriers and solutions through interactive knowledge sharing.</li>
+  </ul>"
+  registration-page: https://www.eventbrite.com/e/reproducibility-for-everyone-tickets-523807130227
+  recording:
+  slides: https://docs.google.com/presentation/d/1v_5CRrCpkPSYYXK29URfNRWKPd3w5tH9svvB_sHbjhw/edit#slide=id.g2084be53121_0_94
+
+- title: "GIS & Mapping: Where to Start"
+  name: gismap
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Susan Powell, org: ucb-lib}
+  ]
+  img:  gis.png
+  thumbnail:  gis.png
+  alt:  "stylized globe of the earth"
+  day: t
+  time: 1-2pm
+  start: 1
+  duration: 60
+  type: lecture
+  description: "Interested in digital mapping and GIS (geographic information science), but not sure where to start? Have some experience, but want to learn more about what the campus has to offer? This virtual workshop is for you! We'll provide an overview of the GIS and digital mapping landscape as a whole, including: which tools are out there and how to choose the right one for your needs, common terms used in the field, resources for learning how to get started mapping, and where to go to find data to create your first project.
+
+No experience or special software is required to participate in this workshop. The Zoom link to the workshop will be sent to registrants 24 hours in advance."
+  registration-page: https://berkeley.libcal.com/event/10172779
+  recording:
+  slides: http://ucblib.link/GIS-LDW23
+
+- title: Developing your data science portfolio
+  name: dscportfolio
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Michele Tobias, org: ucd-dl},
+    {name: Pamela Reynolds, org: ucd-dl}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: t
+  time: 2-4pm
+  start: 2
+  duration: 120
+  type: hands-on
+  description: "How can you demonstrate your technical skills to a potential employer,
+    supervisor, funder, or collaborator? During this workshop we will discuss digital
+    (online) portfolios, which complement your CV/resume by showcasing your coding,
+    data visualization, data analysis, mapmaking, and other skilled technical abilities.
+    We will discuss various purposes for digital portfolios, the components of a digital
+    portfolio, methods and tools for creating one, and considerations for carefully
+    curating and presenting your work in an engaging manner. By the end of this workshop,
+    participants will be able to: identify personally relevant reasons to create a
+    digital portfolio; describe basic components of a digital portfolio; identify
+    tools for creating and curating their digtial portofolio; and find examples of
+    digital portfolios related to their career goals (programmers, data scientists,
+    geospatial scientists, etc.)."
+  registration-page: https://registration.genomecenter.ucdavis.edu/events/DevelopingYourDataSciencePortfolio/
+  recording:
+  slides:
+
+#Wednesday
+
+- title: How to Get Wikidata Using SPARQL
+  name: sparql
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Kat Koziar, org: ucr-lib},
+    {name: Leigh Phan, org: ucla-dsc}
+  ]
+  img:  Wikidata-logo-v3_sparql.png
+  thumbnail:  Wikidata-logo-v3_sparql.png
+  alt:  "wikidata logo on clear background: stylized bar codes with bars in three colors (red, green, and blue) with the words wikidata and SPARQL beneath"
+  day: w
+  time: 10am-12pm
+  start: 10
+  duration: 120
+  type: hands-on
+  description: Wikidata is a free structured knowledge base, currently with over 100 million items. Its records include people, objects, works of art, places, events, geographies, concepts, and even journal articles. Wikidata also includes the relationships between items. This hands-on introductory workshop will provide an overview of item records in Wikidata, including how they are structured and described, and a demonstration on how to retrieve these items using the query language SPARQL.
+
+    No previous knowledge of Wikidata or SPARQL is necessary, but we highly recommend attending the Wikidata Basics workshop held on Monday, February 13, 2023.
+  registration-page: https://www.eventbrite.com/e/how-to-get-wikidata-using-sparql-tickets-488815569527
+  recording:
+  slides:
+
+- title: R-Users Group
+  name: rusers
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Wesley Brooks, org: ucd-dl},
+    {name: Liza Wood, org: ucd-dl}
+  ]
+  img: R_logo.png
+  thumbnail: R_logo.png
+  alt: "Large letter R"
+  day: h
+  time: 10am-12pm
+  start: 10
+  duration: 120
+  type: discussion
+  description: "Come join the Davis R Users Group to talk about all things R! In this
+    'birds of a feather' session we invite you to talk about how you use R for your
+    research data analyses and visualizations, general questions you have about the
+    language, and/or how to start a community of practice for R users at your institution."
+  registration-page: https://registration.genomecenter.ucdavis.edu/events/RUsersGroupCross-UCMeetup/
+  recording:
+  slides:
+
+- title: WiDS Datathon Onboarding
+  name: wids
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Pamela Reynolds, org: ucd-dl}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: w
+  time: 12pm-1pm
+  start: 12
+  duration: 60
+  type: lecture
+  description: "The 6th Annual Women in Data Science (WiDS) Datathon is open until March 1, 2023. This year’s Datathon focuses on utilizing data science to better prepare and adapt to the challenges caused by climate change and extreme weather events. Participants are challenged to blend machine-learning and physics-based forecasts to improve long-term weather forecasting, thereby helping communities and industries adapt to the challenges of climate change.<br><br>
+At this event we will cover:<br>
+<ul><li>What the Datathon is all about</li>
+<li>Signing up for the Datathon</li>
+<li>Getting registered on Kaggle</li>
+<li>Joining the WiDS Datathon Slack organization</li>
+<li>Forming and finding a team by connecting with other participants</li>
+<li>Exploring existing notebooks, tutorials, and other Datathon resources.</li>
+</ul>
+
+Whether a beginner or experienced data scientist, everyone is welcome to participate. The Datathon is open to individuals or teams of up to 4, and at least half of each team must be individuals who identify as women."
+  registration-page: https://ucdavis.zoom.us/meeting/register/tJIqf--rpjsoHNCQQFbq81YJwkyY0XLjiBFP
+  recording:
+  slides:
+
+- title: Wikipedia edit-a-thon
+  name: wikipediaedit
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Ann Glusker, org: ucb-lib},
+    {name: Stacy Reardon, org: ucb-lib},
+    {name: Corliss Lee, org: ucb-lib},
+    {name: Margaret Philips, org: ucb-lib}
+  ]
+  img:  wikipedia_logo.png
+  thumbnail:  wikipedia_logo.png
+  alt:  "wikipedia logo: globe with icons over the words wikipedia"
+  day: w
+  time: 1-2:30pm
+  start: 1
+  duration: 90
+  type: hands-on
+  description: "Wikipedia’s inclusion trouble is well-documented. While the reasons
+    are up for debate, the practical effect of this disparity is not: content is skewed
+    by the lack of participation by underrepresented groups. This adds up to an alarming
+    absence in an important repository of shared knowledge. Let’s change that! Join
+    us on Zoom for a tutorial for the beginner Wikipedian followed by communal updating
+    of Wikipedia entries."
+  registration-page: https://guides.lib.berkeley.edu/wikipedia-edit-a-thon
+  recording:
+  slides: https://drive.google.com/file/d/1PY5QpW9_UjyWTTjJQILTQ8fQvJglP9qD/view
+
+- title: Data De-identification in Practice
+  name: deidentification
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Renata Curty, org: ucsb},
+    {name: Greg Janee, org: ucsb}
+  ]
+  img: R_logo.png
+  thumbnail: R_logo.png
+  alt: "Large letter R"
+  day: w
+  time: 2-4pm
+  start: 2
+  duration: 120
+  type: hands-on
+  description: This workshop will cover key definitions, recommendations, and techniques
+    to implement data de-identification/anonymization. Attendees will be invited to
+    follow along and complete exercises with a provided dataset using the online graphical
+    user interface of the R sdcMicro package for disclosure control. No R programming
+    experience is required.
+  registration-page: https://www.library.ucsb.edu/events-exhibitions/data-de-identification-practice
+  recording:
+  slides: https://docs.google.com/presentation/d/1F3GigLLjrrpF3MEr3gxct9dM62W6kICbuO-gongmKUg/edit?usp=share_link
+
+- title: Exploring Digital Archives
+  name: digiarchives
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Wendy Kurtz, org: ucla},
+    {name: Anthony Caldwell , org: ucla}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: w
+  time: 3-5pm
+  start: 3
+  duration: 120
+  type: demo
+  description: Do you need to search digital archives for hidden treasures and unknown tidbits 
+    for your research projects? This workshop will explore the tools and techniques that allow 
+    you to capture, search, and synthesize information stored in digital archives. Using the 
+    internet archive as an example, we will combine the power of  DEVONthink, a document and 
+    information management tool that allows you to collect, organize, edit, and annotate 
+    documents of any kind,  Tinderbox, and Obsidian sophisticated note-taking applications 
+    designed to capture and analyze complex relationships and ideas and Zotero a reference 
+    manager used to capture and manage bibliographic data and related research materials.
+  registration-page: https://ucla.zoom.us/meeting/register/tJwofuqgqjwsHtb6qudplOdauzem397b-V2j
+  recording:
+  slides:
+
+#Thursday
+
+- title: Responsible Data Science
+  name: responsibledsc
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Pamela Reynolds & team, org: ucd-dl}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: h
+  time: 10am-12pm
+  start: 10
+  duration: 120
+  type: hands-on
+  description: "Technical advancements through data science combined with the exponential increase in data has led to research breakthroughs across domains and generated entirely new industries. But, lagging behind this growth is our understanding of the evolving socio-technical landscape and ability to predict the indirect consequences of our work. While laws determine the legal parameters governing data use, data science approaches that are technically legal can still be used unethically and irresponsibly, with disastrous consequences from loss of revenue to human rights violations. Through case studies and interactive sessions, this workshop provides an overview of how to practice responsible data science by incorporating considerations of ethics, equity, and justice. We will discuss FACT (fairness, accuracy, confidentiality, and transparency) based approaches to increasing the integrity of our work in data science. By the end of this workshop, learner should be able to:
+    Describe examples of how the development of data science can both contribute to inequities and be leveraged to address them in their own domain.
+    Begin to identify the underlying goals and incentives influencing their data-driven research.
+    Assess whether a research project’s data meets FAIR criteria.
+    Use a responsible data science framework to evaluate the potential impact(s) of a research project case study.
+    Revise their research design using FACT principles."
+  registration-page: https://registration.genomecenter.ucdavis.edu/events/ResponsibleDataScience/
+  recording:
+  slides:
+
+- title: "Introduction to containers: creating reproducible, scalable, and portable
+    workflows"
+  name: containers
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Orion Cohen, org: ucb-rit},
+    {name: Alex Goldberg, org: ucb-rit},
+    {name: Wei Feinstein, org: ucb-rit}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: h
+  time: 12-1pm
+  start: 12
+  duration: 60
+  type: lecture
+  description: This training will introduce you to the key concepts and tools for
+    using containers, in particular Docker and Singularity containers. Containers
+    make it easy to install software, move your computation between different computing
+    environments, and make your workflow reproducible. In this training, we will discuss
+    the advantages of containers, how to create containers, and how to use containers
+    in several common scientific computing scenarios.
+  registration-page: https://berkeley.zoom.us/meeting/register/tJAuc-GsqzkiGtBQorHz4QWD0GMMdwuMcz7y
+  recording: https://www.youtube.com/watch?v=n8KvqG-bkj4 
+  slides: https://docs.google.com/presentation/d/1ok4WtUYFF0GDRqYcFroCfsnhDx6aZTS6NKhWc7n_9p4/edit
+
+- title: Julia User Group
+  name: julia
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Nick Ulle, org: ucd-dl},
+    {name: Carl Stahmer, org: ucd-dl}
+  ]
+  img: julia_logo.png
+  thumbnail: julia_logo.png
+  alt: "the word julia with colored dots"
+  day: h
+  time: 1-2pm
+  start: 1
+  duration: 60
+  type: discussion
+  description: "Are you using Julia? If so, come join the Davis Julia Users Group!
+    In this 'birds of a feather' session we invite you to talk about how you learned
+    to use Julia, what problems you are tackling with it, and how you've integrated
+    the language into your research workflows."
+  registration-page: https://registration.genomecenter.ucdavis.edu/events/JuliaUsersGroupCross-UCMeetup/
+  recording:
+  slides:
+
+- title: Using Library Collections for Computational Research
+  name: libcollections
+  speaker-type: "Speaker"
+  speakers: [
+  {name: Rachel Starry, org: ucr-lib},
+  {name: Sandy Enriquez, org: ucr-lib}, 
+  {name: Kathryn Stine, org: ucsf},
+  {name: Charlie Macquarie, org: ucsf}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: h
+  time: 2-3pm
+  start: 2
+  duration: 60
+  type: lecture
+  description: Whether you are a student, researcher, or library worker, library collections are a 
+    rich potential source of data for research or community projects. The concept of "collections as 
+    data" relates to the responsible use and reuse of cultural heritage materials, university archives, 
+    and other digitized records for data-driven research in both the sciences and humanities. UC 
+    libraries are increasingly joining other cultural heritage stewards in providing researchers 
+    with datasets drawn from their collections.<br><br>
+    This workshop will introduce participants to both technical resources and ethical considerations 
+    for the reuse of library collections as research data. We will discuss the importance of metadata 
+    and documentation when using collections as data, and will look at one tool for computationally 
+    analyzing collections (HathiTrust Research Center Analytics). We will also explore some specific 
+    collections held by UCR Library and UCSF Library Archives & Special Collections that are available 
+    to use as data for historical research.
+
+  registration-page: https://www.eventbrite.com/e/using-library-collections-for-computational-research-tickets-487940512207
+  recording:
+  slides:
+
+#Friday
+
+- title: Data-Driven Animation for Research and Science Communication
+  name: animationcomm
+  speaker-type: "Speaker"
+  speakers: [
+  {name: Dr. Jessie Kendall Bar, org: ucsd}
+   ]
+  img: data_driven_animation.png
+  thumbnail: data_driven_animation.png
+  alt: "computer derived image of marine animal with boxes indicating movement"
+  day: f
+  time: 10-11:30am
+  start: 10
+  duration: 90
+  type: hands-on
+  description: In this 90-minute workshop, Dr. Jessica Kendall-Bar will introduce
+    techniques that transform data into visualizations that accelerate research and
+    facilitate communication. Kendall-Bar will share tools and tips to bring your
+    data to life with data visualization tools and coding languages from PowerPoint
+    to R, Python, Javascript, ArcGIS, Adobe After Effects, and Autodesk Maya. We will
+    share tutorials and demos, show examples of the visualizations that are possible
+    within these programs, and have some time at the end to do some collective dataviz
+    brainstorming regarding specific datasets from workshop attendees.
+  registration-page: https://ucsd.zoom.us/meeting/register/tJ0sduGqqD8rHNWJNjSNlaB9N9hKJY11SJYZ
+  recording:
+  slides:
+
+- title: Wikidata edit-a-thon
+  name: wikidataedit
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Kat Koziar, org: ucr-lib},
+    {name: Leigh Phan, org: ucla-dsc}
+  ]
+  img:  Wikidata-logo-v3.png
+  thumbnail:  Wikidata-logo-v3.png
+  alt:  "wikidata logo on clear background: stylized bar codes with bars in three colors (red, green, and blue) with the word wikidata beneath"
+  day: f
+  time: 10am-1pm
+  start: 10
+  duration: 120
+  type: hands-on
+  description: Join us for a Wikidata edit-a-thon!  This is a great opportunity to
+    learn basic Wikidata editing skills, and how Wikidata can be relevant to your
+    research.  From 10 - 11am, we'll cover how to add and edit Wikidata items.  From
+    11am until 1pm, you can choose your level of participation.  Dive into some hands-on
+    solo editing or ask questions.  While you can bring your own data projects, we
+    will have a project list, so everything you need to successfully edit or upload
+    a Wikidata item will be provided during the session.  <br><br>No previous knowledge
+    of Wikidata is necessary, but we highly recommend attending the Wikidata Basics
+    workshop held on Monday, February 13, 2023.
+  registration-page: https://www.eventbrite.com/e/wikidata-edit-a-thon-tickets-488819912517
+  recording:
+  slides:
+
+- title: "Getting started with qualitative data analysis: open tools and methods"
+  name: qualdata
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Ann Glusker, org: ucb-lib}
+  ]
+  img:  ldw-circuit-color-506_2022.png
+  thumbnail:  ldw-circuit-color-506_2022.png
+  alt:  "love data week logo image: internal circuitry in the shape of a heart with abbreviations of the UC campuses, ANR, and CDL interspersed"
+  day: f
+  time: 1-2pm
+  start: 1
+  duration: 60
+  type: demo
+  description: "This workshop will give an overview of basic qualitative research methods, starting with (a little) theory, and moving on to sampling and theme development. We will then take a look at open tools for qualitative data analysis. After a brief demo of Taguette, other tools, such as QDA Miner, qcoder and QualCoder, will be reviewed.  Additional resources will be mentioned and the slides/links made available."
+  registration-page: https://berkeley.libcal.com/event/10172847
+  recording:
+  slides: https://tinyurl.com/LDW23-QualData
+
+- title: Intro to ArcGIS Pro
+  name: gisintro
+  speaker-type: "Speaker"
+  speakers: [
+    {name: Maggi Kelly, org: ucb},
+    {name: Sean Hogan, org: anr}
+  ]
+  img:  gis.png
+  thumbnail:  gis.png
+  alt:  "stylized globe of the earth"
+  day: f
+  time: 1-4pm
+  start: 1
+  duration: 180
+  type: hands-on
+  description: ArcGIS Pro is ESRI's powerhouse desktop application for all things
+    GIS. It can do anything from basic cartography to advanced geospatial modeling,
+    and is well intergrated with web mapping and accessing online data. This introductory
+    workshop will get you started creating maps using local and online GIS data. All
+    UC students and staff should have access to ArcGIS software (to find out who to
+    contact at your campus, see https://uc-gis-ucop.hub.arcgis.com). Temporary workshop
+    licenses are also available.
+  registration-page: https://igis.ucanr.edu/Training/IntroArcGISPro_Feb2023/
+  recording: https://youtu.be/Jrf1zzWniWU 
+  slides:

--- a/_includes/2023_includes/header-menu.html
+++ b/_includes/2023_includes/header-menu.html
@@ -15,20 +15,21 @@
   <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
     <ul class="nav navbar-nav navbar-right">
       <li class="nav-item">
-        <a class="page-scroll" href="{{ site.baseurl }}/#workshops">Workshops</a>
+        <a class="page-scroll" href="{{ site.baseurl }}/2023/#workshops">Workshops</a>
       </li>
 
       <li class="nav-item">
-        <a class="page-scroll"  href="{{ site.baseurl }}/calendar">Calendar</a>
+        <a class="page-scroll"  href="{{ site.baseurl }}/2023/calendar">Calendar</a>
       </li>
 
       <li class="nav-item">
-        <a class="page-scroll"  href="{{ site.baseurl }}/#contact">Campus Contacts</a>
+        <a class="page-scroll"  href="{{ site.baseurl }}/2023/#contact">Campus Contacts</a>
       </li>
 
       <li class="dropdown">
         <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Previous Years <span class="caret"></span></a>
         <ul class="submenu dropdown-menu" id="past-events-collapse">
+          <li><a class="page-scroll"  href="{{ site.baseurl }}/2023">2023</a></li>
           <li><a class="page-scroll"  href="{{ site.baseurl }}/2022">2022</a></li>
           <li><a class="page-scroll" href="{{ site.baseurl }}/2021/">2021</a></li>
         </ul>

--- a/_includes/2023_includes/workshops_info.html
+++ b/_includes/2023_includes/workshops_info.html
@@ -28,7 +28,7 @@
                                 {%- if forloop.index != workshop_days.size -%}
                                 &nbsp;-&nbsp;
                                 {%- endif -%}
-                            {%- endfor -%}, {{ post.time }} | <a href="{{ site.base.url }}/calendar">Calendar</a></p>
+                            {%- endfor -%}, {{ post.time }} | <a href="{{ site.base.url }}/2023/calendar">Calendar</a></p>
                            <hr class="star-primary">
                             <img src="../assets/img/workshops/{{ post.img }}" class="img-responsive img-centered" alt="{{ post.alt }}">
                             {% if post.speakers[0].name != "none" %}

--- a/_includes/2024_includes/calendar.html
+++ b/_includes/2024_includes/calendar.html
@@ -1,0 +1,336 @@
+    {% comment %}
+        Data is stored in yml files, which must be captured using liquid.
+    {% endcomment %}
+
+    {%- capture workshop_info -%}
+        {%- for workshop in site.data.yml_2023.workshops -%}
+             {{workshop.title}}&&{{workshop.day}}&&{{workshop.time}}&&{{workshop.start}}&&{{workshop.duration}}&&{{workshop.type}}&&{{workshop.recording}}&&{{workshop.slides}}&&{{workshop.reader}}&&{{workshop.registration-page}}&&{{workshop.url}}&&{{workshop.temp}}&&{{workshop.name}}%%
+        {%- endfor -%}
+    {%- endcapture -%}
+
+            {% assign dates = site.data.yml_2023.dates %}
+        {% assign currentDate = 'now' | date: "%Y%m%d" | plus:0 %}
+
+    {%- capture days_info -%}
+        {%- for day in site.data.yml_2023.dates -%}
+             {{day.date}}&&{{day.day-full}}&&{{day.day-abbv}}&&{{day.iso8601}}%%
+        {%- endfor -%}
+    {%- endcapture -%}
+
+    {% comment %}
+        The data is then converted to javascript objects since javascript provides the coding
+        functionality needed to create the calendar view
+    {% endcomment %}
+    <script type="text/javascript">
+        // for displaying variables outside of the context of the calendar,
+        // the html needs to be pushed down a little so it is visible beneath the page menu
+//        document.write ('<hr><hr><hr><hr>')
+
+        // basic global variables; it's easier to have it here RN vs a single yml file
+        // although, we might revisit having global variables in a yml file,
+        // as long as the data doesn't get too cluttered.
+        var day_start = 9;  // assumes am
+        var day_end = 5;  // assumes pm
+        var block_duration = 30;  // in minutes
+
+
+
+        // convert liquid variable for conference days info to javascript objects
+        let days_info = '{{days_info}}';
+            days_info = days_info.split('%%')
+            days_info = days_info.slice(0, days_info.length-1)
+
+        var conference_days_text = new Array(days_info.length);
+        var conference_days_abbv = new Array(days_info.length);
+        var conference_days_date = new Array(days_info.length);
+        var conference_days_iso8601 = new Array(days_info.length);
+
+        for (let i = 0; i < days_info.length; i++){
+            let day_info = days_info[i].split('&&');
+            conference_days_date[i] = day_info[0];
+            conference_days_text[i] = day_info[1];
+            conference_days_abbv[i] = day_info[2];
+            conference_days_iso8601[i] = day_info[3];
+        }
+
+        var modal = 1; // do we want the modal popup? will remove links except for modal. is binary 1/0
+
+/**/    let currentDate = new Date();
+        let isoDate = (currentDate.getFullYear()*10000)+((currentDate.getMonth()+1)*100)+(currentDate.getDate())
+        // registration open based on current date. if open, will show reg/url links; if not, will show materials links. if modal is active, will not show registration or mats links. is binary 1/0
+        if(isoDate<=conference_days_iso8601[conference_days_iso8601.length-1]){
+            var reg_open = 1;
+        }else
+        {
+            var reg_open = 0;
+        }
+        var reg_open = 0;
+
+
+        // this array contains each time slot for the day.  semi-hard coded for 30 minute intervals
+        var times_array = new Array((day_end+12-day_start)*(60/block_duration));
+            times_array[0] = day_start;
+            for (let i = 1; i < times_array.length; i++){
+                // this part will need be edited if interval lengths are changes
+                times_array[i] = times_array[i-1]*1 + (block_duration/60);
+                if (times_array[i] == 13) times_array[i] = 1;
+            }
+
+        // convert liquid variable for workshop info to javascript objects
+        let workshop_info = '{{workshop_info}}';
+            workshop_info = workshop_info.split('%%')
+            workshop_info = workshop_info.slice(0, workshop_info.length-1)
+
+        let workshop_title = new Array(1);
+        let workshop_day = new Array(1);
+        let workshop_time = new Array(1);
+        let workshop_duration = new Array(1);
+        let workshop_start = new Array(1);
+        let workshop_type = new Array(1);
+        let workshop_recording = new Array(1);
+        let workshop_slides = new Array(1);
+        let workshop_reader = new Array(1);
+        let workshop_registration = new Array(1);
+        let workshop_url = new Array(1);
+        let workshop_temp = new Array(1);
+        let workshop_name = new Array(1);
+
+        let index = 0;  // need to keep track of index separately,
+                        // since some workshops are held across multiple days
+        for (let i = 0; i < workshop_info.length; i++){
+            let wk_info = workshop_info[i].split('&&');
+            if(wk_info[1].length > 1){
+                let days = wk_info[1].split(',')
+/*                document.write ('<p>length before'+workshop_slot_count+' '+days.length+'</p>')/**/
+
+                for (let j = 0; j < days.length; j++){
+/*                document.write ('<p>what is wk_info[1][j]: '+days[j]+'</p>')/**/
+                    workshop_title[index] = wk_info[0];
+                    workshop_day[index] = days[j];
+                    workshop_time[index] = wk_info[2];
+                    workshop_start[index] = wk_info[3];
+                    workshop_duration[index] = wk_info[4];
+                    workshop_type[index] = wk_info[5];
+                    workshop_recording[index] = wk_info[6];
+                    workshop_slides[index] = wk_info[7];
+                    workshop_reader[index] = wk_info[8];
+                    workshop_registration[index] = wk_info[9];
+                    workshop_url[index] = wk_info[10];
+                    workshop_temp[index] = wk_info[11];
+                    workshop_name[index] = wk_info[12];
+                    index = index+1
+/*                document.write ('<p>workshop info: '+workshop_title[index-1]+' '+workshop_name[index-1]+'</p>')/**/
+
+                }
+/*                document.write ('<p>length after'+workshop_slot_count+'</p>')/**/
+            }else{
+            workshop_title[index] = wk_info[0];
+            workshop_day[index] = wk_info[1];
+            workshop_time[index] = wk_info[2];
+            workshop_start[index] = wk_info[3];
+            workshop_duration[index] = wk_info[4];
+            workshop_type[index] = wk_info[5];
+            workshop_recording[index] = wk_info[6];
+            workshop_slides[index] = wk_info[7];
+            workshop_reader[index] = wk_info[8];
+            workshop_registration[index] = wk_info[9];
+            workshop_url[index] = wk_info[10];
+            workshop_temp[index] = wk_info[11];
+            workshop_name[index] = wk_info[12];
+            index = index+1
+/*                document.write ('<p>workshop info: '+workshop_title[index-1]+' '+workshop_day[index-1]+'</p>')/**/
+
+            }
+        }
+
+
+        // a nested array where each cell represents a single day/time
+        var week_total_workshops = new Array((day_end+12-day_start)*2);
+            for (let i = 0; i < week_total_workshops.length; i++){
+                week_total_workshops[i] = new Array(conference_days_abbv.length).fill(0);
+            }
+
+        // this populates how many workshops are in each time slot, so we can determine
+        // the span required for each day of the week, and make the calendar look nice
+        for (let i = 0; i < workshop_title.length; i++){
+            let blocks = workshop_duration[i]/block_duration;
+            let timeIndex = times_array.indexOf(workshop_start[i]*1);
+            let dayIndex = conference_days_abbv.indexOf(workshop_day[i]);
+            for (let j = timeIndex; j < (blocks+timeIndex); j++){
+                    week_total_workshops[j][dayIndex] = (week_total_workshops[j][dayIndex])+1;
+            }
+        }
+
+
+        // reduces the rows to find the max value for each column
+        // results in max number of columns per day
+        var maxCol = new Array(conference_days_abbv.length);
+        for (let i = 0 ; i < maxCol.length; i++){
+            maxCol[i] = Math.max.apply(Math, week_total_workshops.map(v => v[i]));
+        }
+
+        // this array will contain the html for each time/day
+        // all columns in each row will eventually be joined so each element represents
+        // a single time, or row in the html table that displays the calendar view
+        var week_rows = new Array((day_end+12-day_start)*2);
+            for (let i = 0; i < week_total_workshops.length; i++){
+                week_rows[i] = new Array(conference_days_abbv.length).fill("");
+            }
+
+        // this array will contain how many workshops are written to each time slot, so we can determine
+        // the span required for each day of the week, and make the calendar look nice
+        var week_workshops_written = new Array((day_end+12-day_start)*2);
+            for (let i = 0; i < week_workshops_written.length; i++){
+                week_workshops_written[i] = new Array(conference_days_abbv.length).fill(0);
+            }
+
+
+
+
+/*                document.write ('<p>populate workshop info</p>')/**/
+
+        for (let i = 0; i < workshop_title.length; i++){
+            let blocks = workshop_duration[i]/block_duration;
+            let timeIndex = times_array.indexOf(workshop_start[i]*1);
+            let dayIndex = conference_days_abbv.indexOf(workshop_day[i]);
+
+            /* before event text, url and registration links */
+            let registration = ''
+            let url = ''
+            let recording = ''
+            let slides = ''
+            let reader = ''
+            let mats = ''
+
+            if(modal){
+                modal_html=' ><a href="#'+workshop_name[i]+'" data-toggle="modal">'+ workshop_title[i] +'</a>'
+            }else{
+                modal_html=' >'+ workshop_title[i]
+            }
+
+
+            if(reg_open){
+                if(workshop_registration[i]!=""){
+                    if(modal){
+                        registration = '<i>Registration open</i>'
+                    }else{
+                    registration = '<a href="' + workshop_registration[i] + '" target="_blank" title="Link to workshop registration" onclick="getOutboundLink( '+workshop_registration[i]+' ); return false;">Registration</a>'
+                }
+                }
+                if(workshop_url[i]!=""){
+                    if(modal){
+                        registration = '<i>Registration open</i>'
+                    }else{
+
+                    url = '<a href="' + workshop_url[i] + '" target="_blank" title="Link to workshop page with registration" onclick="getOutboundLink( '+workshop_url[i]+' ); return false;">Workshop page (with registration)</a>'
+                }
+                }
+                if(url == "" && registration ==""){
+                    url = '<i>Registration coming soon</i>'
+                }
+
+/*                week_rows[timeIndex][dayIndex]=week_rows[timeIndex][dayIndex]+ ' <td style="border: 1px solid white; border-radius: 10px 10px 10px 10px; border-spacing: 1;" colspan="1" rowspan="'+blocks+'"  class='+workshop_type[i]+ modal_html +'<span>'+registration+' '+url+' </span></td>';/**/
+
+            }else {  // after event, to include recordings, slides, and readers
+                if(workshop_temp[i] && url==""){
+                    url = '<i>'+workshop_temp[i]+'</i>'
+                }
+
+                if((workshop_recording[i]!="")||(workshop_slides[i]!="")||(workshop_reader[i]!="")){
+                    if(modal){mats="<i>Available Materials:</i><br>"}
+                }
+
+                if(workshop_recording[i]!=""){
+                    if(modal){
+                        recording = '- Recording<br>'
+                    }else{
+
+                        recording = '<a class="calendar" href="' + workshop_recording[i] + '" target="_blank" title="Link to workshop recording" onclick="getOutboundLink( '+workshop_recording[i]+' ); return false;">Recording</a>'
+                    }
+                }
+                if(workshop_slides[i]!=""){
+                    if(modal){
+                        slides = '- Slides<br>'
+                    }else{
+
+                    slides = '<a class="calendar" href="' + workshop_slides[i] + '" target="_blank" title="Link to workshop slides" onclick="getOutboundLink( '+workshop_slides[i]+' ); return false;">Slides</a>'
+                }
+                }
+                if(workshop_reader[i]!=""){
+                    if(modal){
+                        reader = '- Reader<br>'
+                    }else{
+
+                    reader = '<br><a class="calendar" href="' + workshop_reader[i] + '" target="_blank" title="Link to workshop reader" onclick="getOutboundLink( '+workshop_reader[i]+' ); return false;">Reader</a>'
+                }
+                }
+/*                week_rows[timeIndex][dayIndex]=week_rows[timeIndex][dayIndex]+ ' <td style="border: 1px solid white; border-radius: 10px 10px 10px 10px; border-spacing: 1;" colspan="1" rowspan="'+blocks+'"  class='+workshop_type[i]+ modal_html +'<span>'+recording+' '+slides+' '+reader+' </span></td>';/**/
+            }
+                week_rows[timeIndex][dayIndex]=week_rows[timeIndex][dayIndex]+ ' <td style="border: 1px solid white; border-radius: 10px 10px 10px 10px; border-spacing: 1;" colspan="1" rowspan="'+blocks+'"  class='+workshop_type[i]+ modal_html +'<span>'+registration+' '+url+mats+recording+' '+slides+' '+reader+' </span></td>';/**/
+
+            for (let k = timeIndex; k < (blocks+timeIndex); k++){
+                week_workshops_written[k][dayIndex] = (week_workshops_written[k][dayIndex])+1;
+            }
+        } // end for
+
+
+        // this loop will fill in the column spans required to align the calendar
+        // and use blank space to group workshops
+        for(let i = 0; i < week_rows.length; i++){
+            for(let j = 0; j < week_rows[i].length; j++){
+                if (week_workshops_written[i][j] < maxCol[j]){
+                    let temp = (maxCol[j]*1 -week_workshops_written[i][j]*1)
+                    week_rows[i][j] = week_rows[i][j] + ' <td colspan="'+temp +'" style="border: thin dotted #9a9a9c;"" > </td>';
+                }
+            }
+        }
+
+        // collapses the nested array so it can be cleanly written to html
+        for(let i = 0; i < week_rows.length; i++){
+            week_rows[i] = week_rows[i].join(" ");
+        }
+    </script>
+
+
+    <div  class="event calendar-frame" <!-- -->
+        <!-- p><center>2023 Calendar coming soon.  In the meantime, check out the recordings, slides, and other materials from last year's event.</center></p -->
+      <h1>2023 Calendar</h1>
+<div class="tableFixHead">
+<table class="calendar">
+  <body class="calendar" >
+  </colgroup>
+    <thead><tr>
+            <th style="text-align: center;  border: 1px solid white; border-radius: 10px 10px 10px 10px; border-spacing: 1;" scope="col">Time</th>
+            <script>
+                for (let i = 0; i < conference_days_text.length; i++){
+                    document.write ('<th style="text-align: center;  border: 1px solid white; border-radius: 10px 10px 10px 10px; border-spacing: 1;" scope="col" colspan="'+ maxCol[i]+ '"">'+ conference_days_text[i]+ '<br>' +conference_days_date[i]+ '</th>')
+                }
+            </script>
+
+        </tr>
+    </thead>
+    <script>
+        for (let i = 0; i < times_array.length; i += 2){
+             document.write ('<tr><th>'+ ((times_array[i] < 10) ? '0': ''),times_array[i]+':00</th>'+ week_rows[i] + '</tr>')
+             document.write ('<tr><th>'+ ((times_array[i] < 10) ? '0': ''),times_array[i]+':30</th>'+ week_rows[i+1] + '</tr>')/**/
+        }
+    </script>
+    </tr></thead>
+
+
+</body>
+</table>
+</div>
+<br>
+      <div style="display:inline-block; background-color: #d3d3d3; padding:5px; margin:5px; overflow-x: hidden; width:auto; border-radius: 10px 10px 10px 10px;">
+        <table class="calendar" style="width: auto; border: 1px dashed lightgrey; border-radius: 10px 10px 10px 10px;">
+            <tr><td>Workshop legend:</td>
+                {%- for legend in site.data.yml_2023.workshop_type -%}
+                     <td style="border: 1px solid #d3d3d3; border-radius: 10px 10px 10px 10px; border-spacing: 1;  text-align: center;" class='{{legend.type}}'>{{legend.type_description_short}}</td>
+                {%- endfor -%}
+            </tr>
+
+        </table>
+    </div>
+
+    </div>

--- a/_includes/2024_includes/calendar.html
+++ b/_includes/2024_includes/calendar.html
@@ -3,16 +3,16 @@
     {% endcomment %}
 
     {%- capture workshop_info -%}
-        {%- for workshop in site.data.yml_2023.workshops -%}
+        {%- for workshop in site.data.yml_2024.workshops -%}
              {{workshop.title}}&&{{workshop.day}}&&{{workshop.time}}&&{{workshop.start}}&&{{workshop.duration}}&&{{workshop.type}}&&{{workshop.recording}}&&{{workshop.slides}}&&{{workshop.reader}}&&{{workshop.registration-page}}&&{{workshop.url}}&&{{workshop.temp}}&&{{workshop.name}}%%
         {%- endfor -%}
     {%- endcapture -%}
 
-            {% assign dates = site.data.yml_2023.dates %}
+            {% assign dates = site.data.yml_2024.dates %}
         {% assign currentDate = 'now' | date: "%Y%m%d" | plus:0 %}
 
     {%- capture days_info -%}
-        {%- for day in site.data.yml_2023.dates -%}
+        {%- for day in site.data.yml_2024.dates -%}
              {{day.date}}&&{{day.day-full}}&&{{day.day-abbv}}&&{{day.iso8601}}%%
         {%- endfor -%}
     {%- endcapture -%}
@@ -293,8 +293,8 @@
 
 
     <div  class="event calendar-frame" <!-- -->
-        <!-- p><center>2023 Calendar coming soon.  In the meantime, check out the recordings, slides, and other materials from last year's event.</center></p -->
-      <h1>2023 Calendar</h1>
+        <!-- p><center>2024 Calendar coming soon.  In the meantime, check out the recordings, slides, and other materials from last year's event.</center></p -->
+      <h1>2024 Calendar</h1>
 <div class="tableFixHead">
 <table class="calendar">
   <body class="calendar" >

--- a/_includes/2024_includes/contact.html
+++ b/_includes/2024_includes/contact.html
@@ -1,0 +1,24 @@
+<section id="contact">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading">Campus Contacts</h2>
+                    <h3 class="section-subheading text-muted">Questions about UC Love Data Week?  </h3>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                        <div class="row">
+                            {% for post in site.data.yml_2024.contacts %}
+                            <div class="col-md-6">
+                                <p class="text-muted"><u>{{ post.campus }}</u><br>
+                                    {{ post.name }}<br>
+                                    {{ post.email }}
+                                </p>
+                            </div>
+                            {% endfor %}
+                        </div>
+                </div>
+            </div>
+        </div>
+    </section>

--- a/_includes/2024_includes/footer.html
+++ b/_includes/2024_includes/footer.html
@@ -1,0 +1,32 @@
+<style>
+body {
+  position: absolute;
+  margin: 0;
+  min-height: 100%;
+  width: 100%;
+}
+
+footer {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+</style>
+
+<footer>
+    <div class="container">
+        <div class="row">
+            <div >
+                <span>Adapted from the <a href="https://github.com/melvinchng/event-jekyll-theme">Event Jekyll Theme</a> by <a href="http://melvinchng.github.io">Melvin Ch'ng</a></span>
+            </div>
+            <!-- div class="col-md-4">
+                <ul class="list-inline social-buttons">
+                    {% for network in site.social %}
+                        <li><a href="{{ network.url }}"><i class="fa fa-{{ network.title }}"></i></a></li>
+                    {% endfor %}
+                </ul>
+            </div -->
+        </div>
+    </div>
+</footer>

--- a/_includes/2024_includes/head.html
+++ b/_includes/2024_includes/head.html
@@ -1,0 +1,91 @@
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <meta name="viewport" content="width=device-width">
+    <meta name="description" content="{{ site.description }}">
+    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+    
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K8HVZ7G');</script>
+    <!-- End Google Tag Manager -->
+
+    {% seo %}
+
+    <!-- Custom CSS & Bootstrap Core CSS - Uses Bootswatch Flatly Theme: http://bootswatch.com/flatly/ -->
+    <link rel="stylesheet" href="{{ "../css/2016_style/style.css" | prepend: site.baseurl }}">
+    <link rel="stylesheet" href="{{ "../css/calendar-style.css" | prepend: site.baseurl }}">
+
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9D8Y189SW3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-9D8Y189SW3');
+    </script>
+    <!--Google Analytics SCRIPT END-->
+
+    <script>
+    /**
+    * Function that registers a click on an outbound link in Analytics.
+    * This function takes a valid URL string as an argument, and uses that URL string
+    * as the event label. Setting the transport method to 'beacon' lets the hit be sent
+    * using 'navigator.sendBeacon' in browser that support it.
+    */
+    var getOutboundLink = function(url) {
+      gtag('event', 'click', {
+        'event_category': 'outbound',
+        'event_label': 'UC <3 Data Week home: '+url,
+        'transport_type': 'beacon',
+        'event_callback': function(){window.open(url);}
+      });
+    }
+    </script>
+
+    <script>
+         function stopVideo(vidframeID) {
+        //First get the  iframe URL
+            var vidurl = $(vidframeID).attr('src');
+
+            //Then assign the src to null, this then stops the video been playing
+            $(vidframeID).attr('src', '');
+
+            // Finally you reasign the URL back to your iframe, so when you hide and load it again you still have the link
+            $(vidframeID).attr('src', vidurl);/**/
+    }
+    </script>
+
+
+    <!--Remove image dragging -->
+    <BODY ondragstart="return false;" ondrop="return false;">
+
+    <!-- Custom Fonts -->
+    <link rel="stylesheet" href="{{ "../css/2016_style/font-awesome/css/font-awesome.min.css" | prepend: site.baseurl }}">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
+    <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+    <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
+
+    <!-- WEBSITE ICON IN BROWSER -->
+    <link rel="icon" type="image/png" href="/css/2016_style/img/icon.png">
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+        <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+    <![endif]-->
+</head>

--- a/_includes/2024_includes/header-home.html
+++ b/_includes/2024_includes/header-home.html
@@ -1,0 +1,3 @@
+    <nav class="navbar navbar-default navbar-default-color navbar-fixed-top">
+        {% include 2024_includes/header-menu.html %}
+    </nav>

--- a/_includes/2024_includes/header-menu.html
+++ b/_includes/2024_includes/header-menu.html
@@ -1,0 +1,41 @@
+
+<div class="container">
+  <!-- Brand and toggle get grouped for better mobile display -->
+  <div class="navbar-header page-scroll">
+    <button type="button" class="navbar-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <a class="navbar-brand page-scroll" href="/"><img src="../assets/img/ldw-circuit-light-transparent.png" style="margin-top:-15px" height="50px" alt="UC &#128151; Data Week">UC &#128151; Data Week</a>
+  </div>
+
+  <!-- Collect the nav links, forms, and other content for toggling -->
+  <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+    <ul class="nav navbar-nav navbar-right">
+      <li class="nav-item">
+        <a class="page-scroll" href="{{ site.baseurl }}/#workshops">Workshops</a>
+      </li>
+
+      <li class="nav-item">
+        <a class="page-scroll"  href="{{ site.baseurl }}/calendar">Calendar</a>
+      </li>
+
+      <li class="nav-item">
+        <a class="page-scroll"  href="{{ site.baseurl }}/#contact">Campus Contacts</a>
+      </li>
+
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Previous Years <span class="caret"></span></a>
+        <ul class="submenu dropdown-menu" id="past-events-collapse">
+          <li><a class="page-scroll"  href="{{ site.baseurl }}/2023">2023</a></li>
+          <li><a class="page-scroll"  href="{{ site.baseurl }}/2022">2022</a></li>
+          <li><a class="page-scroll" href="{{ site.baseurl }}/2021/">2021</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</div>
+<!-- /.container-fluid -->

--- a/_includes/2024_includes/header-menu.html
+++ b/_includes/2024_includes/header-menu.html
@@ -14,14 +14,15 @@
   <!-- Collect the nav links, forms, and other content for toggling -->
   <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
     <ul class="nav navbar-nav navbar-right">
+      <!-- comment out workshops and calendar on header until update for year
       <li class="nav-item">
         <a class="page-scroll" href="{{ site.baseurl }}/#workshops">Workshops</a>
       </li>
 
       <li class="nav-item">
-        <a class="page-scroll"  href="{{ site.baseurl }}/calendar">Calendar</a>
+        <a class="page-scroll"  href="{{ site.baseurl }}/#calendar">Calendar</a>
       </li>
-
+    -->
       <li class="nav-item">
         <a class="page-scroll"  href="{{ site.baseurl }}/#contact">Campus Contacts</a>
       </li>

--- a/_includes/2024_includes/header.html
+++ b/_includes/2024_includes/header.html
@@ -1,0 +1,5 @@
+<!-- Navigation -->
+    <nav class="navbar navbar-default navbar-fixed-top">
+        {% include 2024_includes/header-menu.html %}
+
+    </nav>

--- a/_includes/2024_includes/interim.html
+++ b/_includes/2024_includes/interim.html
@@ -1,0 +1,10 @@
+<!-- Services Section -->
+    <section id="intro">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading">Workshop Info Coming Soon</h2>
+                </div>
+            </div>
+        </div>
+    </section>

--- a/_includes/2024_includes/intro.html
+++ b/_includes/2024_includes/intro.html
@@ -1,0 +1,24 @@
+<!-- Services Section -->
+<section id="intro">
+  <div class="container">
+    <div class="row">
+      <!-- Added inline styling because vertical spacing elements don't exist in Bootstrap 3. -->
+      <div class="col-md-6" style="padding-bottom:15px">
+        <h2 class="section-heading text-center">How Do You &#128151; Your Data?</h2>
+        <div class="intro-text">
+          <div class="intro-lead-in">February 12 - 16, 2024</div>
+        </div>
+        <p>UC Love Data Week is a week-long offering of presentations and workshops focused 
+          on data access, management, security, sharing, and preservation.  Whether you're 
+          working on qualitative or quantitative data, we've got events for you! All members 
+          of the University of California community are welcome to attend. Make sure to 
+          register with your UC-campus email.
+        </p>
+       <!-- <center><a href="#workshops" class="page-scroll btn btn-xl" style="word-break: normal;">Workshop <br>Information</a></center>  -->
+      </div>
+      <div class="col-md-6" style="padding-bottom:15px">
+        <img style="width: 100%; height: 100%;" src="/assets/img/ldw-circuit-color_2022.png" width="auto">
+      </div>
+    </div>
+  </div>
+</section>

--- a/_includes/2024_includes/js.html
+++ b/_includes/2024_includes/js.html
@@ -1,0 +1,14 @@
+<!-- jQuery Version 1.11.0 -->
+<script src="{{ "../css/2016_style/js/jquery-1.11.0.js" | prepend: site.baseurl }}"></script>
+
+<!-- Bootstrap Core JavaScript -->
+<script src="{{ "../css/2016_style/js/bootstrap.min-old.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "../css/2016_style/js/bootstrap.min.js" | prepend: site.baseurl }}"></script>
+
+<!-- Plugin JavaScript -->
+<script src="{{ "../css/2016_style/js/jquery.easing.min.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "../css/2016_style/js/classie.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "../css/2016_style/js/cbpAnimatedHeader.js" | prepend: site.baseurl }}"></script>
+
+<!-- Custom Theme JavaScript -->
+<script src="{{ "../css/2016_style/js/agency.js" | prepend: site.baseurl }}"></script>

--- a/_includes/2024_includes/logo.html
+++ b/_includes/2024_includes/logo.html
@@ -1,0 +1,1 @@
+<a href="/logo"><img class="web-logo" src="/assets/img/ldw-circuit-color_2022.png"></a>

--- a/_includes/2024_includes/sponsors.html
+++ b/_includes/2024_includes/sponsors.html
@@ -1,0 +1,22 @@
+<!-- Clients Aside -->
+
+    <aside class="clients" class="bg-light-gray">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading">Participating Campuses</h2>
+                </div>
+            </div>
+            <div class="row">
+                {% for campus in site.data.yml_2024.campuses %}
+                    {% if campus.p-campus == "y" %}
+                    <div class="col-md-4 col-sm-6" style="height:200px;">
+                        <a href="{{ campus.url }}" class="portfolio-link" data-toggle="modal" target="_blank">
+                            <img src= {{ campus.image }} class="img-responsive img-centered" alt="{{ campus.alt }}" width="300">
+                        </a>
+                    </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+    </aside>

--- a/_includes/2024_includes/workshop_speakers.html
+++ b/_includes/2024_includes/workshop_speakers.html
@@ -1,0 +1,36 @@
+<!-- gather and sort speakers. value for no speaker is "none" -->
+{% assign speakers-list = site.data.yml_2024.workshops | map: "speakers" %}
+{% assign speakers-list-temp = speakers-list | uniq | sort_natural: "name" %}
+{% assign speakers-list = speakers-list-temp %}
+
+<!-- Portfolio Grid Section -->
+    <section id="speakers" class="bg-light-gray">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading">Workshop Speakers</h2>
+                    <h3 class="section-subheading text-muted"></h3>
+                </div>
+            </div>
+            <div class="row">
+                    {% for speaker in speakers-list  %}
+                    {% if speaker.name != "none" %}{% if speaker.name != "TBA" %}
+                    <div class="col-md-4 col-sm-6 text-center" style="padding: 15px; ">
+                        <div  style="height:200px; border: 1px solid lightgrey; padding: 0 15px 15px 15px;">
+                            <h2>{{ speaker.name }}</h2>
+                            <hr class="star-primary">
+                                {% for campus in site.data.yml_2024.campuses %}
+                                    {% if speaker.org == campus.abbv %}
+                                        <img src="{{ campus.image }}" class="img-responsive img-centered" alt="{{ campus.alt }}" style="max-height: 85px;">
+                                    {% endif %}
+                                {% endfor %}
+                            <!-- a href="{{ campus.url }}" class="portfolio-link" data-toggle="modal" target="_blank">
+                                <img src= {{ campus.image }} class="img-responsive img-centered" alt="{{ campus.alt }}" height="50">
+                            </a -->
+                        </div>
+                    </div>
+
+                    {% endif %}{% endif %}
+                    {% endfor %}
+            </div>
+    </section>

--- a/_includes/2024_includes/workshops-list.html
+++ b/_includes/2024_includes/workshops-list.html
@@ -1,0 +1,46 @@
+<!-- Portfolio Grid Section -->
+    <section id="workshops" class="bg-light-gray">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading">Workshop List</h2>
+                    <h3 class="section-subheading text-muted"></h3>
+                          <div style="display:inline-block; background-color: #d3d3d3; padding:5px; margin:5px; overflow-x: hidden; width:auto; border-radius: 10px 10px 10px 10px;">
+        <div class="container-fluid">
+        <div class="row p-4" > <strong>Workshop Legend</strong><br>
+                {%- for legend in site.data.yml_2024.workshop_type -%}
+                     <div class="col-4 {{legend.type}} workshop-list " style="float:right;">{{legend.type_description_short}}</div>
+                {%- endfor -%}
+        </div>
+   </div>
+    </div>
+
+                </div>
+            </div>
+            
+          {% for post in site.data.yml_2024.workshops %}
+          <div class="row {{post.type}} workshop-list">
+
+                <div class="col-sm-4">
+                    {% if post.day | size > 1 %}
+                                {% assign workshop_days = post.day | split: "," %}
+                            {% else %}
+                                {% assign workshop_days = post.day %}
+                            {% endif %}
+                            <span class="text-dark">
+                            {%- for workshop_day in workshop_days -%}
+                                {%- for day in site.data.yml_2024.dates -%}
+                                    {%- if workshop_day == day.day-abbv -%}
+                                    {{day.day-full }}
+                                    {%- endif -%}
+                                {%- endfor -%}
+                                {%- if forloop.index != workshop_days.size -%}
+                                &nbsp;-&nbsp;
+                                {%- endif -%}
+                            {%- endfor -%}, {{ post.time }}</span>
+                </div>
+                <div class="col-sm-8"><a href="#{{ post.name }}" class="speakers-link" data-toggle="modal">{{ post.title }}</a></div>
+            </div>
+          {% endfor %}
+        </div>
+    </section>

--- a/_includes/2024_includes/workshops.html
+++ b/_includes/2024_includes/workshops.html
@@ -1,0 +1,65 @@
+<!-- Portfolio Grid Section -->
+    <section id="workshops" class="bg-light-gray">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading">Workshop Info</h2>
+                    <h3 class="section-subheading text-muted"></h3>
+                </div>
+            </div>
+            <div class="row">
+          {% for post in site.data.yml_2024.workshops %}
+                <div class="col-md-4 col-sm-6 speakers-item">
+                    <div style="height:600px;">
+                        <a href="#{{ post.name }}" class="speakers-link" data-toggle="modal">
+                            <div class="speakers-hover">
+                                <div class="speakers-hover-content">
+                                    <i class="fa fa-plus fa-3x"></i>
+                                </div>
+                            </div>
+                            <div style="display: table-cell; height:310px; vertical-align: middle;">
+                            <img src="../assets/img/workshops/{{ post.thumbnail }}" class="img-responsive img-centered" alt="{{ post.alt }}" width="300">
+                        </div>
+                        </a>
+                        <div class="speakers-caption">
+                            <h4>{{ post.title }}</h4>
+                            {% assign mats = false %}
+                            {% if post.slides or post.reader %}
+                                {% assign mats = true %}
+                            {% endif %}
+                            {% if mats or post.recording %}
+                            <p><i>
+                                {% if post.recording %}
+                                    Recording
+                                {% endif %}
+                                {% if post.recording and mats %}
+                                and
+                                {% endif %}
+                                {% if mats %}
+                                    Materials
+                                {% endif %}
+                             Available</i></p>
+                            {% endif %}
+                            {% if post.day | size > 1 %}
+                                {% assign workshop_days = post.day | split: "," %}
+                            {% else %}
+                                {% assign workshop_days = post.day %}
+                            {% endif %}
+                            <p class="text-muted-dark">
+                            {%- for workshop_day in workshop_days -%}
+                                {%- for day in site.data.yml_2024.dates -%}
+                                    {%- if workshop_day == day.day-abbv -%}
+                                    {{day.day-full }}
+                                    {%- endif -%}
+                                {%- endfor -%}
+                                {%- if forloop.index != workshop_days.size -%}
+                                &nbsp;-&nbsp;
+                                {%- endif -%}
+                            {%- endfor -%}, {{ post.time }}</p>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+            </div>
+        </div>
+    </section>

--- a/_includes/2024_includes/workshops_info.html
+++ b/_includes/2024_includes/workshops_info.html
@@ -1,0 +1,148 @@
+ <!-- Portfolio Modals -->
+ {% for post in site.data.yml_2024.workshops %}
+    <div class="portfolio-modal modal fade" id="{{ post.name }}" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-content">
+            <div class="close-modal" data-dismiss="modal">
+                <div class="lr">
+                    <div class="rl">
+                    </div>
+                </div>
+            </div>
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-8 col-lg-offset-2">
+                        <div class="modal-body">
+                            <h2>{{ post.title }}</h2>
+                            {% if post.day | size > 1 %}
+                                {% assign workshop_days = post.day | split: "," %}
+                            {% else %}
+                                {% assign workshop_days = post.day %}
+                            {% endif %}
+                            <p>
+                            {%- for workshop_day in workshop_days -%}
+                                {%- for day in site.data.yml_2024.dates -%}
+                                    {%- if workshop_day == day.day-abbv -%}
+                                    {{day.day-full }}
+                                    {%- endif -%}
+                                {%- endfor -%}
+                                {%- if forloop.index != workshop_days.size -%}
+                                &nbsp;-&nbsp;
+                                {%- endif -%}
+                            {%- endfor -%}, {{ post.time }} | <a href="{{ site.base.url }}/calendar">Calendar</a></p>
+                           <hr class="star-primary">
+                            <img src="../assets/img/workshops/{{ post.img }}" class="img-responsive img-centered" alt="{{ post.alt }}">
+                            {% if post.speakers[0].name != "none" %}
+                                <p>{{ post.speaker-type }}: {% for speaker in post.speakers %}
+                                {{- speaker.name -}}
+                                {% for campus in site.data.yml_2024.campuses %}
+                                    {% if speaker.org == campus.abbv %}
+                                        ({{campus.name}})
+                                    {% endif %}
+                                {% endfor %}
+                                {% if forloop.index != post.speakers.size %}
+                                -
+                                {% endif %}
+                                {% endfor %}
+                                </p>
+                            {% endif %}
+                            <p>{{ post.description }}</p>
+                            {% comment %}
+                            The below blocks are for registration.  You can delete them, or leave it in.  The code will not display unless the appropriate fields are set in workshops.yml.
+                            {% endcomment %}
+                            <h3>Event Registration Information</h3>
+<!--  -->
+                            {% assign dates = site.data.yml_2024.dates %}
+                            {% assign currentDate = 'now' | date: "%Y%m%d" | plus:0 %}
+                                {% if currentDate <= dates.last.iso8601 %}
+                                    {% assign reg = true %}
+
+                                    {% comment %}
+                                    EVENTBRITE
+                                    {% endcomment %}
+                                    {% if post.eventbrite %}
+                                        <iframe
+                                          src="https://www.eventbrite.com/tickets-external?eid={{post.eventbrite}}&ref=etckt"
+                                          frameborder="0"
+                                          width="100%"
+                                          height="280px"
+                                          scrolling="auto">
+                                        </iframe>
+                                        {% assign reg = false %}
+                                    {% endif %}
+
+                                    {% comment %}
+                                    ZOOM
+                                    {% endcomment %}
+                                    {% if post.zoom %}
+                                        <iframe src="https://zoom.us/meeting/register/{{post.zoom}}" width="1000px" height="500px"></iframe>
+                                        {% assign reg = false %}
+                                    {% endif %}
+
+                                    {% comment %}
+                                        Register on website
+                                    {% endcomment %}
+                                    {% if post.registration-page %}
+                                        <p>Click <a href="{{post.registration-page}}" target="_blank"  title="Link to Registration page"
+                                            onclick="getOutboundLink( {{post.registration-page}} ); return false;">here</a> to register. <br></p>
+                                        {% assign reg = false %}
+                                        {% elsif post.url  %}
+                                        <p>Campus Event <a href="{{post.url}}" target="_blank" title="Link to campus event page"
+                                            onclick="getOutboundLink( {{post.url}} ); return false;">page</a>. <br></p>
+                                        {% assign reg = false %}
+                                    {% endif %}
+                                    {% comment %}
+                                    ICAL
+                                    {% endcomment %}
+                                    {% if post.ical %}
+                                    <p>Add to Calendar using iCal.  <a class="btn btn-default" href="{{post.ical}}" title="Add to Calendar using iCal" id="s-lc-event-b-c"><i class="fa fa-calendar fa-lg"></i></a><br></p>
+                                    {% endif %}
+
+                                    {% if post.temp %}
+                                    <p><i>{{post.temp}}</i> </p>
+                                    {% elsif reg  %}
+                                    <p>Registration information coming soon!</p>
+                                    {% endif %}
+                                {% else %} <!--  -->
+                                    <p>This is a past event.  Registration is closed.</p>
+<!--  -->                                {% endif %} <!--  -->
+
+
+<!--     -->                       {% comment %}
+                            The below blocks are for slides and recordings.  You can delete them, or leave it in.  The code will not display unless the appropriate fields are set in workshops.yml.
+                            {% endcomment %}
+                            {% if post.slides or post.reader or post.recording %}
+                                <p><strong>Workshop Materials</strong>:
+                                {% if post.slides %}
+                                    <a href="{{post.slides}}" target="_blank" title="Link to workshop slides" onclick="getOutboundLink( {{post.slides}} ); return false;">Slides</a>
+                                {% endif %}
+                                {% if post.slides and post.reader %}
+                                -
+                                {% endif %}
+                                {% if post.reader %}
+                                    <a href="{{post.reader}}" target="_blank" title="Link to workshop reader" onclick="getOutboundLink( {{post.reader}} ); return false;">Reader or other Materials</a>
+                                {% endif %}
+                                {% if post.slides and post.recording and post.reader %}
+                                -
+                                {% elsif post.reader and post.recording %}
+                                -
+                                {% elsif post.slides and post.recording %}
+                                -
+                                {% endif %}
+                                {% if post.recording %}
+                                    <a href="{{post.recording}}" target="_blank" title="Link to workshop recording" onclick="getOutboundLink( {{post.recording}} ); return false;">Recording</a>
+
+                                {% endif %}
+                                </p>
+                            {% endif %}
+
+
+                            <p onclick="stopVideo('#playerid_{{ post.name }}');">
+                                <button type="button" class="btn btn-default" data-dismiss="modal" ><i class="fa fa-times"></i> Close</button>
+                            </p> <!-- -->
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endfor %}

--- a/_includes/2024_includes/workshops_test.html
+++ b/_includes/2024_includes/workshops_test.html
@@ -1,0 +1,65 @@
+<!-- Portfolio Grid Section -->
+    <section id="workshops" class="bg-light-gray">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading">Workshops</h2>
+                    <h3 class="section-subheading text-muted"></h3>
+                </div>
+            </div>
+            <div class="row">
+            {% for post in site.data.yml_2024.workshops %}
+                <div class="col-md-4 col-sm-6 speakers-item">
+                    <div style="height:600px;">
+                        <a href="#{{ post.name }}" class="speakers-link" data-toggle="modal">
+                            <div class="speakers-hover">
+                                <div class="speakers-hover-content">
+                                    <i class="fa fa-plus fa-3x"></i>
+                                </div>
+                            </div>
+                            <div style="display: table-cell; height:310px; vertical-align: middle;">
+                            <img src="../assets/img/workshops/{{ post.thumbnail }}" class="img-responsive img-centered" alt="{{ post.alt }}" width="300">
+                        </div>
+                        </a>
+                        <div class="speakers-caption">
+                            <h4>{{ post.title }}</h4>
+                            {% assign mats = false %}
+                            {% if post.slides or post.reader %}
+                                {% assign mats = true %}
+                            {% endif %}
+                            {% if mats or post.recording %}
+                            <p><i>
+                                {% if post.recording %}
+                                    Recording
+                                {% endif %}
+                                {% if post.recording and mats %}
+                                and
+                                {% endif %}
+                                {% if mats %}
+                                    Materials
+                                {% endif %}
+                             Available</i></p>
+                            {% endif %}
+                            {% if post.day | size > 1 %}
+                                {% assign workshop_days = post.day | split: "," %}
+                            {% else %}
+                                {% assign workshop_days = post.day %}
+                            {% endif %}
+                            <p class="text-muted-dark">
+                            {%- for workshop_day in workshop_days -%}
+                                {%- for day in site.data.yml_2024.dates -%}
+                                    {%- if workshop_day == day.day-abbv -%}
+                                    {{day.day-full }}
+                                    {%- endif -%}
+                                {%- endfor -%}
+                                {%- if forloop.index != workshop_days.size -%}
+                                &nbsp;-&nbsp;
+                                {%- endif -%}
+                            {%- endfor -%}, {{ post.time }}</p>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+            </div>
+        </div>
+    </section>

--- a/_layouts/2024_home_TBA.html
+++ b/_layouts/2024_home_TBA.html
@@ -11,7 +11,7 @@
       <!-- End Google Tag Manager (noscript) -->
 
 
-    {% include 2024_includes/header-home.html %}
+  {% include 2024_includes/header-home.html %}
 
   <!-- Do not include workshop info in dev page -->
    {% include 2024_includes/intro.html %}

--- a/_layouts/2024_home_TBA.html
+++ b/_layouts/2024_home_TBA.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+  {% include 2024_includes/head.html %}
+
+
+    <body id="page-top" class="index">
+      <!-- Google Tag Manager (noscript) -->
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K8HVZ7G"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <!-- End Google Tag Manager (noscript) -->
+
+
+    {% include 2024_includes/header-home.html %}
+
+  <!-- Do not include workshop info in dev page -->
+   {% include 2024_includes/intro.html %}
+   {% include 2024_includes/interim.html %}
+   {% include 2024_includes/sponsors.html %}
+   {% include 2024_includes/contact.html %}
+   {% include 2024_includes/footer.html %}
+   {% include 2024_includes/js.html %}
+
+    </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,3 @@
 ---
-layout: 2023_home
+layout: 2024_home_TBA
 ---


### PR DESCRIPTION
PR addressing 3/8 tasks in [issue #65](https://github.com/uc-love-data-week/uc-love-data-week.github.io/issues/65). Commits archive 2023 content (accessible via header menu drop down for 'previous years') and stages 2024 site (main page has 'workshops coming soon').

Note:  

This does _not_ resolve [issue #64](https://github.com/uc-love-data-week/uc-love-data-week.github.io/issues/64). Workshops header menu still needs to be fixed for 2023 and 2024 content.

Calendar from header menu still points to 2023 calendar; will update automatically when yml_2024 data is updated to reflect 2024 workshosp.