### PR TITLE
update workshop anchor/link from header in both 2023 & 2024

### DIFF
--- a/_includes/2023_includes/workshops-list.html
+++ b/_includes/2023_includes/workshops-list.html
@@ -1,5 +1,5 @@
 <!-- Portfolio Grid Section -->
-    <section id="workshops" class="bg-light-gray">
+    <section id="workshops-list" class="bg-light-gray">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">

--- a/_includes/2024_includes/workshops-list.html
+++ b/_includes/2024_includes/workshops-list.html
@@ -1,5 +1,5 @@
 <!-- Portfolio Grid Section -->
-    <section id="workshops" class="bg-light-gray">
+    <section id="workshops-list" class="bg-light-gray">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">


### PR DESCRIPTION
Addresses issue #64. Fixed both 2023 & 2024 by updating the anchor id in `202N_includes/workshops-list.html` from `section id="workshops"` to `section id="workshops-list"`