### PR TITLE
complete some steps for staging 2024 pages (solution for _why isn't agenda showing when `published=true`?_), and resolve conflicts

### DIFF
--- a/_2024_pages/index.html
+++ b/_2024_pages/index.html
@@ -1,6 +1,6 @@
 ---
 layout: 2024_home_TBA
-permalink: /index
+permalink: /2024/index
 title: UC Love Data Week 2024
 published: true
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ social:
 
 google_site_verification: googleXXXXXXXXXXXXXXXX.html
 
-include: ['_2016_pages', '_2021_pages', '_2022_pages', '_2023_pages']
+include: ['_2016_pages', '_2021_pages', '_2022_pages', '_2023_pages', '_2024_pages']
 
 plugins:
   - jekyll-sitemap

--- a/_layouts/2024_default.html
+++ b/_layouts/2024_default.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+  <style type="text/css">
+    /*INCLUDE MAIN CSS FILE*/
+    {% capture criticalcss %}
+      {% include /2016_css/critical.scss %}
+    {% endcapture %}
+    {{ criticalcss | scssify }}
+  </style>
+
+  {% include /2016_data/js.html %}
+  {% include /2024_includes/head.html %}
+
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K8HVZ7G"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    {% include /2024_includes/header.html %}
+        {{ content }}
+  </body>
+  {% include /2024_includes/footer.html %}
+</html>


### PR DESCRIPTION
- add 2024 pages to config to include in build. 
- fix index conflict w/..index.html & ../_2024_pages/index.html. 
- add 2024 default layout for agenda, calendar, and soon to be search page