### PR TITLE
update agenda.html to use 2024_default as layout; fix typo in dates.yml

### DIFF
--- a/_2024_pages/agenda.html
+++ b/_2024_pages/agenda.html
@@ -1,5 +1,5 @@
 ---
-layout: 2024_home_TBA
+layout: 2024_default
 permalink: /agenda
 title: Agenda
 published: true

--- a/_data/yml_2024/dates.yml
+++ b/_data/yml_2024/dates.yml
@@ -1,7 +1,7 @@
 - date: Feb 12, 2024
   day-full: Monday
   day-abbv: m
-  iso8601: 220240212
+  iso8601: 20240212
 
 - date: Feb 13, 2024
   day-full: Tuesday


### PR DESCRIPTION
This should fix the agenda page so it renders correctly. 